### PR TITLE
Add Roslyn analyzers

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,181 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = CRLF
+indent_style = space
+indent_size = 4
+insert_final_newline = false
+trim_trailing_whitespace = true
+
+[*.sln]
+indent_style = tab
+
+[*.{csproj,vbproj,vcxproj,vcxproj.filters}]
+indent_size = 2
+
+[*.{xml,config,props,targets,nuspec,ruleset}]
+indent_size = 2
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[*.json]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.sh]
+end_of_line = lf
+
+[*.cs]
+# Prefer file scoped namespace declarations
+csharp_style_namespace_declarations = file_scoped:warning
+
+# Sort using and Import directives with System.* appearing first
+dotnet_sort_system_directives_first = true
+dotnet_separate_import_directive_groups = false
+
+# Avoid "this." and "Me." if not necessary
+dotnet_style_qualification_for_field = false:refactoring
+dotnet_style_qualification_for_property = false:refactoring
+dotnet_style_qualification_for_method = false:refactoring
+dotnet_style_qualification_for_event = false:refactoring
+
+# Use language keywords instead of framework type names for type references
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+dotnet_style_predefined_type_for_member_access = true:suggestion
+
+# Suggest more modern language features when available
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+
+# Non-private static fields are PascalCase
+dotnet_naming_rule.non_private_static_fields_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.non_private_static_fields_should_be_pascal_case.symbols = non_private_static_fields
+dotnet_naming_rule.non_private_static_fields_should_be_pascal_case.style = non_private_static_field_style
+dotnet_naming_symbols.non_private_static_fields.applicable_kinds = field
+dotnet_naming_symbols.non_private_static_fields.applicable_accessibilities = public, protected, internal, protected_internal, private_protected
+dotnet_naming_symbols.non_private_static_fields.required_modifiers = static
+dotnet_naming_style.non_private_static_field_style.capitalization = pascal_case
+
+# Non-private readonly fields are PascalCase
+dotnet_naming_rule.non_private_readonly_fields_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.non_private_readonly_fields_should_be_pascal_case.symbols = non_private_readonly_fields
+dotnet_naming_rule.non_private_readonly_fields_should_be_pascal_case.style = non_private_readonly_field_style
+dotnet_naming_symbols.non_private_readonly_fields.applicable_kinds = field
+dotnet_naming_symbols.non_private_readonly_fields.applicable_accessibilities = public, protected, internal, protected_internal, private_protected
+dotnet_naming_symbols.non_private_readonly_fields.required_modifiers = readonly
+dotnet_naming_style.non_private_readonly_field_style.capitalization = pascal_case
+
+# Constants are PascalCase
+dotnet_naming_rule.constants_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.constants_should_be_pascal_case.symbols = constants
+dotnet_naming_rule.constants_should_be_pascal_case.style = constant_style
+dotnet_naming_symbols.constants.applicable_kinds = field, local
+dotnet_naming_symbols.constants.required_modifiers = const
+dotnet_naming_style.constant_style.capitalization = pascal_case
+
+# Instance fields are camelCase and start with _
+dotnet_naming_rule.instance_fields_should_be_camel_case.severity = suggestion
+dotnet_naming_rule.instance_fields_should_be_camel_case.symbols = instance_fields
+dotnet_naming_rule.instance_fields_should_be_camel_case.style = instance_field_style
+dotnet_naming_symbols.instance_fields.applicable_kinds = field
+dotnet_naming_style.instance_field_style.capitalization = camel_case
+dotnet_naming_style.instance_field_style.required_prefix = _
+
+# Locals and parameters are camelCase
+dotnet_naming_rule.locals_should_be_camel_case.severity = suggestion
+dotnet_naming_rule.locals_should_be_camel_case.symbols = locals_and_parameters
+dotnet_naming_rule.locals_should_be_camel_case.style = camel_case_style
+dotnet_naming_symbols.locals_and_parameters.applicable_kinds = parameter, local
+dotnet_naming_style.camel_case_style.capitalization = camel_case
+
+# Local functions are PascalCase
+dotnet_naming_rule.local_functions_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.local_functions_should_be_pascal_case.symbols = local_functions
+dotnet_naming_rule.local_functions_should_be_pascal_case.style = local_function_style
+dotnet_naming_symbols.local_functions.applicable_kinds = local_function
+dotnet_naming_style.local_function_style.capitalization = pascal_case
+
+# By default, name items with PascalCase
+dotnet_naming_rule.members_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.members_should_be_pascal_case.symbols = all_members
+dotnet_naming_rule.members_should_be_pascal_case.style = pascal_case_style
+dotnet_naming_symbols.all_members.applicable_kinds = *
+dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+
+# Newline settings
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+
+# Indentation preferences
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents = true
+csharp_indent_case_contents_when_block = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = flush_left
+
+# Prefer "var" everywhere
+csharp_style_var_for_built_in_types = true:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+csharp_style_var_elsewhere = true:suggestion
+
+# Prefer method-like constructs to have a block body
+csharp_style_expression_bodied_methods = false:none
+csharp_style_expression_bodied_constructors = false:none
+csharp_style_expression_bodied_operators = false:none
+
+# Prefer property-like constructs to have an expression-body
+csharp_style_expression_bodied_properties = true:none
+csharp_style_expression_bodied_indexers = true:none
+csharp_style_expression_bodied_accessors = true:none
+
+# Suggest more modern language features when available
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+csharp_style_throw_expression = true:suggestion
+csharp_style_conditional_delegate_call = true:suggestion
+
+# Space preferences
+csharp_space_after_cast = false
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_comma = true
+csharp_space_after_dot = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_around_declaration_statements = do_not_ignore
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_before_comma = false
+csharp_space_before_dot = false
+csharp_space_before_open_square_brackets = false
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_between_square_brackets = false
+
+# Blocks are allowed
+csharp_prefer_braces = true:silent
+csharp_preserve_single_line_blocks = true
+csharp_preserve_single_line_statements = true
+
+# warning RS0037: PublicAPI.txt is missing '#nullable enable'
+dotnet_diagnostic.RS0037.severity = none

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ bld/
 [Ll]og/
 [Ll]ogs/
 out/
+src/.vs

--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -1,0 +1,101 @@
+root = false
+
+[*.cs]
+# IDE0055: Fix formatting
+dotnet_diagnostic.IDE0055.severity = warning
+
+# SA1101: Prefix local calls with this
+dotnet_diagnostic.SA1101.severity = none
+
+# SA1633: File should have header
+dotnet_diagnostic.SA1633.severity = none
+
+# SA1201: Elements should appear in the correct order
+dotnet_diagnostic.SA1201.severity = none
+
+# SA1202: Public members should come before private members
+dotnet_diagnostic.SA1202.severity = none
+
+# SA1309: Field names should not begin with underscore
+dotnet_diagnostic.SA1309.severity = none
+
+# SA1404: Code analysis suppressions should have justification
+dotnet_diagnostic.SA1404.severity = none
+
+# SA1516: Elements should be separated by a blank line
+dotnet_diagnostic.SA1516.severity = none
+
+# CA1303: Do not pass literals as localized parameters
+dotnet_diagnostic.CA1303.severity = none
+
+# CSA1204: Static members should appear before non-static members
+dotnet_diagnostic.SA1204.severity = none
+
+# IDE0052: Remove unread private members
+dotnet_diagnostic.IDE0052.severity = warning
+
+# IDE0063: Use simple 'using' statement
+csharp_prefer_simple_using_statement = false:suggestion
+
+# IDE0018: Variable declaration can be inlined
+dotnet_diagnostic.IDE0018.severity = warning
+
+# SA1625: Element documenation should not be copied and pasted
+dotnet_diagnostic.SA1625.severity = none
+
+# IDE0005: Using directive is unnecessary
+dotnet_diagnostic.IDE0005.severity = warning
+
+# SA1117: Parameters should be on same line or separate lines
+dotnet_diagnostic.SA1117.severity = none
+
+# SA1404: Code analysis suppression should have justification
+dotnet_diagnostic.SA1404.severity = none
+
+# SA1101: Prefix local calls with this
+dotnet_diagnostic.SA1101.severity = none
+
+# SA1633: File should have header
+dotnet_diagnostic.SA1633.severity = none
+
+# SA1649: File name should match first type name
+dotnet_diagnostic.SA1649.severity = none
+
+# SA1402: File may only contain a single type
+dotnet_diagnostic.SA1402.severity = none
+
+# CA1814: Prefer jagged arrays over multidimensional
+dotnet_diagnostic.CA1814.severity = none
+
+# RCS1194: Implement exception constructors.
+dotnet_diagnostic.RCS1194.severity = none
+
+# CA1032: Implement standard exception constructors
+dotnet_diagnostic.CA1032.severity = none
+
+# CA1826: Do not use Enumerable methods on indexable collections. Instead use the collection directly
+dotnet_diagnostic.CA1826.severity = none
+
+# RCS1079: Throwing of new NotImplementedException.
+dotnet_diagnostic.RCS1079.severity = warning
+
+# RCS1057: Add empty line between declarations.
+dotnet_diagnostic.RCS1057.severity = none
+
+# RCS1057: Validate arguments correctly
+dotnet_diagnostic.RCS1227.severity = none
+
+# IDE0004: Remove Unnecessary Cast
+dotnet_diagnostic.IDE0004.severity = warning
+
+# CA1810: Initialize reference type static fields inline
+dotnet_diagnostic.CA1810.severity = none
+
+# IDE0044: Add readonly modifier
+dotnet_diagnostic.IDE0044.severity = warning
+
+# RCS1047: Non-asynchronous method name should not end with 'Async'.
+dotnet_diagnostic.RCS1047.severity = none
+
+# RCS1090: Call 'ConfigureAwait(false)'.
+dotnet_diagnostic.RCS1090.severity = warning

--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -77,7 +77,7 @@ dotnet_diagnostic.CA1032.severity = none
 dotnet_diagnostic.CA1826.severity = none
 
 # RCS1079: Throwing of new NotImplementedException.
-dotnet_diagnostic.RCS1079.severity = warning
+dotnet_diagnostic.RCS1079.severity = none
 
 # RCS1057: Add empty line between declarations.
 dotnet_diagnostic.RCS1057.severity = none
@@ -99,3 +99,45 @@ dotnet_diagnostic.RCS1047.severity = none
 
 # RCS1090: Call 'ConfigureAwait(false)'.
 dotnet_diagnostic.RCS1090.severity = warning
+
+# SA1518: Use line endings correctly at end of file
+dotnet_diagnostic.SA1518.severity = none
+
+# SA1512: Single-line comments should not be followed by blank line
+dotnet_diagnostic.SA1512.severity = none
+
+# IDE0011: Add braces
+dotnet_diagnostic.IDE0011.severity = none
+
+# SA1503: Braces should not be omitted
+dotnet_diagnostic.SA1503.severity = none
+
+# SA1600: Elements should be documented
+dotnet_diagnostic.SA1600.severity = none
+
+# SA1500: Braces for multi-line statements should not share line
+dotnet_diagnostic.SA1500.severity = none
+
+# SA1413: Use trailing comma in multi-line initializers
+dotnet_diagnostic.SA1413.severity = none
+
+# SA1502: Element should not be on a single line
+dotnet_diagnostic.SA1502.severity = none
+
+# SA1306: Field names should begin with lower-case letter
+dotnet_diagnostic.SA1306.severity = none
+
+# SA1300: Element should begin with upper-case letter
+dotnet_diagnostic.SA1300.severity = none
+
+# SA1009: Closing parenthesis should be spaced correctly
+dotnet_diagnostic.SA1009.severity = none
+
+# SA1111: Closing parenthesis should be on line of last parameter
+dotnet_diagnostic.SA1111.severity = none
+
+# CS1591: Missing XML comment for publicly visible type or member
+dotnet_diagnostic.CS1591.severity = none
+
+# SA1602: Enumeration items should be documented
+dotnet_diagnostic.SA1602.severity = none

--- a/src/Commands/AddAccountPlanCommand.cs
+++ b/src/Commands/AddAccountPlanCommand.cs
@@ -19,5 +19,4 @@ internal sealed class AddAccountPlanCommand : AsyncCommand<AddAccountPlanCommand
 
         return 0;
     }
-
 }

--- a/src/Commands/AddReaderCommand.cs
+++ b/src/Commands/AddReaderCommand.cs
@@ -30,5 +30,4 @@ internal sealed class AddReaderCommand : AsyncCommand<AddReaderCommandSettings>
 
         return 0;
     }
-
 }

--- a/src/Commands/ParseCommand.cs
+++ b/src/Commands/ParseCommand.cs
@@ -98,7 +98,6 @@ internal sealed class ParseCommand : AsyncCommand<ParseCommandSettings>
             AnsiConsole.Prompt(new TextPrompt<string>("Press enter to exit.").AllowEmpty().Secret(null));
             return 1;
         }
-
     }
 
     private Rows Intro()
@@ -134,7 +133,7 @@ internal sealed class ParseCommand : AsyncCommand<ParseCommandSettings>
                 .Width(60)
                 .AddItem("Posts", journal.Posts.Count, Color.Green)
                 .AddItem("Done", count, Color.Green1),
-            new Grid().AddColumns(3).AddRow(new[]{
+            new Grid().AddColumns(3).AddRow(new[] {
                 new Text(post.Date.ToShortDateString(), new Style(Color.Yellow)),
                 new Text(post.Description, new Style(Color.Cyan1)),
                 new Text(post.Amount.ToString("C"), new Style(post.Amount > 0 ? Color.Green : Color.Red))

--- a/src/Configuration/ConfigState.cs
+++ b/src/Configuration/ConfigState.cs
@@ -1,4 +1,3 @@
-
 public interface IConfigState
 {
     string AccountPlanFileName { get; }

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,4 +1,9 @@
 <Project>
+  <PropertyGroup>
+    <!-- Required to supress SA0001 -->
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
   <ItemGroup Label="Package References">
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435">
       <PrivateAssets>All</PrivateAssets>
@@ -7,4 +12,5 @@
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>
+
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,10 @@
+<Project>
+  <ItemGroup Label="Package References">
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435">
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Roslynator.Analyzers" Version="4.1.2">
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/src/Fabaceae.CLI.sln
+++ b/src/Fabaceae.CLI.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.4.33213.308
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Fabaceae.CLI", "Fabaceae.CLI.csproj", "{B918ED39-815D-4B06-B3EA-5AC097879B89}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{B918ED39-815D-4B06-B3EA-5AC097879B89}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B918ED39-815D-4B06-B3EA-5AC097879B89}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B918ED39-815D-4B06-B3EA-5AC097879B89}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B918ED39-815D-4B06-B3EA-5AC097879B89}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {101A81D8-4B02-4F23-A7C6-5A349D6BAB57}
+	EndGlobalSection
+EndGlobal

--- a/src/Journal/Post.cs
+++ b/src/Journal/Post.cs
@@ -14,5 +14,4 @@ public record Post
     public decimal Amount { get; }
     public string Account { get; }
     public string Comment { get; }
-
 }

--- a/src/Output/DefaultOutputService.cs
+++ b/src/Output/DefaultOutputService.cs
@@ -27,5 +27,4 @@ public class DefaultOutputService : IOutputService
     }
 
     public bool OutputFileExists => File.Exists(OutputFileName);
-
 }

--- a/src/Readers/ExcelReader.cs
+++ b/src/Readers/ExcelReader.cs
@@ -17,7 +17,7 @@ internal sealed class ExcelReader
                 new Post(
                     row.Cell(Config.dateColumnIndex).GetString(),
                     row.Cell(Config.descriptionColumnIndex).GetString(),
-                    Decimal.Parse(row.Cell(Config.amountColumnIndex).GetString()),
+                    decimal.Parse(row.Cell(Config.amountColumnIndex).GetString()),
                     Config.accountName,
                     Config.commentColumnIndex.HasValue ? row.Cell(Config.commentColumnIndex.Value).GetString() : string.Empty
                 )

--- a/src/Readers/ExcelReaderService.cs
+++ b/src/Readers/ExcelReaderService.cs
@@ -23,5 +23,4 @@ internal sealed class ExcelReaderService : IExcelReaderService
         => Readers.FirstOrDefault(r => r.name.Equals(readerParam, StringComparison.OrdinalIgnoreCase));
 
     public IEnumerable<ExcelReaderConfig> Readers => ConfigurationService.Configuration.Readers;
-
 }

--- a/src/TypeRegistrar.cs
+++ b/src/TypeRegistrar.cs
@@ -1,7 +1,7 @@
+// https://github.com/spectreconsole/spectre.console/blob/main/examples/Cli/Injection/Infrastructure/TypeRegistrar.cs
+
 using Microsoft.Extensions.DependencyInjection;
 using Spectre.Console.Cli;
-
-//https://github.com/spectreconsole/spectre.console/blob/main/examples/Cli/Injection/Infrastructure/TypeRegistrar.cs
 
 public sealed class TypeRegistrar : ITypeRegistrar
 {

--- a/src/TypeResolver.cs
+++ b/src/TypeResolver.cs
@@ -1,6 +1,6 @@
-using Spectre.Console.Cli;
+// https://github.com/spectreconsole/spectre.console/blob/main/examples/Cli/Injection/Infrastructure/TypeResolver.cs
 
-//https://github.com/spectreconsole/spectre.console/blob/main/examples/Cli/Injection/Infrastructure/TypeResolver.cs
+using Spectre.Console.Cli;
 
 public sealed class TypeResolver : ITypeResolver, IDisposable
 {

--- a/src/stylecop.json
+++ b/src/stylecop.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
+  "settings": {
+    "documentationRules": {
+      "documentExposedElements": true,
+      "documentInternalElements": false,
+      "documentPrivateElements": false,
+      "documentPrivateFields": false
+    },
+    "layoutRules": {
+      "newlineAtEndOfFile": "allow",
+      "allowConsecutiveUsings": true
+    },
+    "orderingRules": {
+      "usingDirectivesPlacement": "outsideNamespace",
+      "systemUsingDirectivesFirst": true,
+      "elementOrder": [
+        "kind",
+        "accessibility",
+        "constant",
+        "static",
+        "readonly"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Adds Roslyn Analyzers in `Directory.Build.props`, which will make all projects (and new, future ones) use them.

The root `.editorconfig` file contains settings for files in the whole repository, and the .editorconfig file in the `src` folder inherits the rules from the root one and extends them with C#
specific rules.

I've disabled some rules to adhere to what I think is your coding style and fixed some things that I suspect were typos, but feel free to ask me to revert anything.